### PR TITLE
Scaling readed SVG's to 28x28px to match MNIST/EMNIST images format

### DIFF
--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -15,7 +15,9 @@ Grid::Grid(const cv::Point2f &top_left_corner,
   if (m_CellSize <= 0) {
     std::ofstream debug_stream("debug_output.txt",
                                std::ios::app); // Debug output stream
-    debug_stream << "error: grid.cpp: line 18: m_Cell_Size is " << m_CellSize << "instead of positive number\n";
+    debug_stream << "[Grid::Grid(const cv::Point2f &, const cv::Point2f &, "
+                    "float)] Error: m_Cell_Size is "
+                 << m_CellSize << "instead of positive number\n";
     debug_stream.close();
   }
   m_Grid.resize(m_Height);
@@ -99,7 +101,8 @@ bool Grid::HasBeenChecked(std::unordered_multimap<int, int> &checked_pairs,
     if (i->second == pair.second) {
       return true;
     }
-  } 
+  }
+  return false;
 }
 
 } // namespace mathboard

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -15,8 +15,7 @@ Grid::Grid(const cv::Point2f &top_left_corner,
   if (m_CellSize <= 0) {
     std::ofstream debug_stream("debug_output.txt",
                                std::ios::app); // Debug output stream
-    debug_stream << "[Grid::Grid(const cv::Point2f &, const cv::Point2f &, "
-                    "float)] Error: m_Cell_Size is "
+    debug_stream << "[Grid::Grid()] Error: m_Cell_Size is "
                  << m_CellSize << "instead of positive number\n";
     debug_stream.close();
   }

--- a/src/image_processing.cpp
+++ b/src/image_processing.cpp
@@ -1,0 +1,60 @@
+// header
+#include "image_processing.hpp"
+
+// std
+#include <fstream>
+
+namespace mathboard {
+bool RasterizeImage(const std::filesystem::path &filename,
+                    cv::Mat &output_mat) {
+  if (filename.extension() != ".svg") {
+    std::ofstream debug_stream("debug_output.txt",
+                               std::ios::app); // Debug output stream
+
+    debug_stream << "[RasterizeFile] Error: File extension is "
+                 << filename.extension() << " instead of \".svg\"" << std::endl;
+
+    debug_stream.close();
+
+    return false;
+  }
+  cv::VideoCapture video_capture{};
+  video_capture.open(filename.string());
+
+  if (!video_capture.isOpened()) {
+    std::ofstream debug_stream("debug_output.txt",
+                               std::ios::app); // Debug output stream
+
+    debug_stream << "[RasterizeFile] Error: Could not open video. " << filename
+                 << std::endl;
+
+    debug_stream.close();
+
+    return false;
+  }
+
+  if (!video_capture.read(output_mat)) {
+    std::ofstream debug_stream("debug_output.txt",
+                               std::ios::app); // Debug output stream
+
+    debug_stream << "[RasterizeFile] Error: video_capture is empty"
+                 << std::endl;
+
+    debug_stream.close();
+
+    return false;
+  }
+  return true;
+}
+
+void CropImageToSymbol(const cv::Mat &input_mat, cv::Mat &output_mat) {
+  std::vector<std::vector<cv::Point>> contours;
+  cv::findContours(input_mat, contours, cv::RETR_CCOMP,
+                   cv::CHAIN_APPROX_SIMPLE);
+  cv::Rect bounding_box;
+  for (std::size_t i = 0; i < contours.size(); i++) {
+    bounding_box = bounding_box | cv::boundingRect(contours[i]);
+  }
+  output_mat = input_mat(bounding_box);
+}
+} // namespace mathboard

--- a/src/image_processing.cpp
+++ b/src/image_processing.cpp
@@ -47,14 +47,17 @@ bool RasterizeImage(const std::filesystem::path &filename,
   return true;
 }
 
-void CropImageToSymbol(const cv::Mat &input_mat, cv::Mat &output_mat) {
+cv::Mat CropImageToSymbol(const cv::Mat &input_mat) {
   std::vector<std::vector<cv::Point>> contours;
+  // merges bounding boxes of all objects on image
+  // into one bigger bounding box containing all
+  // content of image
   cv::findContours(input_mat, contours, cv::RETR_CCOMP,
                    cv::CHAIN_APPROX_SIMPLE);
   cv::Rect bounding_box;
   for (std::size_t i = 0; i < contours.size(); i++) {
     bounding_box = bounding_box | cv::boundingRect(contours[i]);
   }
-  output_mat = input_mat(bounding_box);
+  return input_mat(bounding_box);
 }
 } // namespace mathboard

--- a/src/image_processing.hpp
+++ b/src/image_processing.hpp
@@ -8,5 +8,5 @@ bool RasterizeImage(const std::filesystem::path &filename, cv::Mat &output_mat);
 
 // `input_array` has to be grayscale
 // crop image to tightly fit symbol on it
-void CropImageToSymbol(const cv::Mat &input_mat, cv::Mat &output_mat);
+cv::Mat CropImageToSymbol(const cv::Mat &input_mat);
 } // namespace mathboard

--- a/src/image_processing.hpp
+++ b/src/image_processing.hpp
@@ -1,0 +1,12 @@
+#include <filesystem>
+#include <opencv2/opencv.hpp>
+
+namespace mathboard {
+// take path to svg file and transform it into pixel representation using
+// cv::Mat
+bool RasterizeImage(const std::filesystem::path &filename, cv::Mat &output_mat);
+
+// `input_array` has to be grayscale
+// crop image to tightly fit symbol on it
+void CropImageToSymbol(const cv::Mat &input_mat, cv::Mat &output_mat);
+} // namespace mathboard


### PR DESCRIPTION
I added two functions to make scaling more efficient and easier. First function made available easy way to convert svg files to pixel form without a need for whole class doing that. Second minimaize data loss when down scaling an image by cutting unneseccary (blank) space of image.